### PR TITLE
fix(gui): Implement focus timeout mechanism to prevent VT focus loss

### DIFF
--- a/extras/include/microui.h
+++ b/extras/include/microui.h
@@ -188,6 +188,7 @@ struct mu_Context {
   mu_Rect last_rect;
   int last_zindex;
   int updated_focus;
+  int focus_timeout;
   int frame;
   mu_Container *hover_root;
   mu_Container *next_hover_root;

--- a/extras/microui/main_microui.c
+++ b/extras/microui/main_microui.c
@@ -61,7 +61,7 @@ static void test_menu(mu_Context *ctx)
                                         /*   comparison                 */
         bool8   diff;                   /* Was difference found during  */
 
-  if (mu_begin_window_ex(ctx, "menu", mu_rect(2, 2, 1020, 30), MU_OPT_NOTITLE|MU_OPT_NORESIZE|MU_OPT_HOLDFOCUS)) {
+  if (mu_begin_window_ex(ctx, "menu", mu_rect(2, 2, 1020, 30), MU_OPT_NOTITLE|MU_OPT_NORESIZE)) {
 
     /* input textbox + submit button */
     static char buf[40];

--- a/extras/microui/microui.c
+++ b/extras/microui/microui.c
@@ -303,6 +303,7 @@ void mu_init(mu_Context *ctx) {
   ctx->draw_frame = draw_frame;
   ctx->_style = default_style;
   ctx->style = &ctx->_style;
+  ctx->focus_timeout = 10;
 
   int i;
   for (i=0; i<N_WIN; i++)
@@ -345,7 +346,14 @@ void mu_end(mu_Context *ctx) {
   }
 
   /* unset focus if focus id was not touched this frame */
-  if (!ctx->updated_focus) { ctx->focus = 0; }
+  if (!ctx->updated_focus) { 
+    ctx->focus_timeout--;
+    if (ctx->focus_timeout <= 0) {
+      ctx->focus = 0;
+    }
+  } else {
+    ctx->focus_timeout = 10; /* Reset timeout when focus is maintained */
+  }
   ctx->updated_focus = 0;
 
   /* bring hover root to front if mouse was pressed */


### PR DESCRIPTION
- Add focus_timeout field to mu_Context structure for grace period handling
- Modify mu_end() to use 10-frame timeout instead of immediate focus clearing
- Remove MU_OPT_HOLDFOCUS from menu to eliminate focus competition
- Initialize focus_timeout to 10 frames (~160ms) in mu_init()

The virtual terminal was losing focus due to aggressive focus management in MicroUI that expected single-threaded operation. The multi-process architecture with VT sleepms(2) delays caused timing mismatches where focus was immediately cleared when updated_focus wasn't set every frame.

This fix introduces a tolerance mechanism that allows focus to survive temporary gaps during VT sleep periods while still being responsive to genuine focus changes when users interact with other windows.

Resolves critical usability issue where keyboard input to virtual terminal was frequently interrupted by focus loss.

close #13